### PR TITLE
Rename variable in custom_notify and update usage

### DIFF
--- a/fau_tools/utils/_color_print.py
+++ b/fau_tools/utils/_color_print.py
@@ -158,8 +158,8 @@ class Color:
     else: raise TypeError(cls.cprint(f"color should be a string or a tuple, but got {type(color)}.", color="red", show=False))
 
     ctitle   = cls.cprint(f" {title} ", color=title_color, bold=True, invert=True, show=False)
-    cconcent = cls.cprint(content, color=content_color, show=False)
-    ctext = " ".join((ctitle, cconcent))
+    ccontent = cls.cprint(content, color=content_color, show=False)
+    ctext = " ".join((ctitle, ccontent))
 
     if show: print(ctext)
     return ctext


### PR DESCRIPTION
## Summary
- fix typo `cconcent` -> `ccontent` in custom_notify
- join title and content using updated variable name

## Testing
- `pyright fau_tools/utils/_color_print.py`
- `python -m py_compile fau_tools/utils/_color_print.py`


------
https://chatgpt.com/codex/tasks/task_e_68a25292477083299d0bd55f672d2759